### PR TITLE
fix empty history function call

### DIFF
--- a/gpaste-reloaded@feuerfuchs.eu/applet.js
+++ b/gpaste-reloaded@feuerfuchs.eu/applet.js
@@ -281,7 +281,7 @@ GPasteApplet.prototype = {
      * Empty the history
      */
     emptyHistory: function() {
-        this.client.emptyHistory(this.historyName, null);
+        this.client.empty_history(this.historyName, null);
     },
 
     /*


### PR DESCRIPTION
This fixes the 'Empty history' in the drop-down applet
